### PR TITLE
マップを作る際何もないときはスキップ

### DIFF
--- a/src/parser_utils.c
+++ b/src/parser_utils.c
@@ -86,6 +86,8 @@ char	**input_map(char **str)
 	char	**map;
 	size_t	i;
 
+	while (*str && !**str)
+		str++;
 	if (!str || !*str)
 		return (NULL);
 	map = malloc(sizeof(char *) * (array_size(str) + 1));


### PR DESCRIPTION
parserの段階でmapの最初の値がないときスキップするように修正

-->
-->11111111111
-->10000000001

のとき
conf->mapの中身が
-->11111111111
-->10000000001

になるように修正

mapに何もないときはNULLを返す